### PR TITLE
Wait for TTS playback and align first response timing

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -19,7 +19,7 @@ import wave
 from collections import deque
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Callable, Deque, Dict, Iterable, List, Optional, Tuple
+from typing import Any, Callable, Deque, Dict, Iterable, List, Optional, Set, Tuple
 
 
 import numpy as np
@@ -85,6 +85,15 @@ class StreamingRecorder:
             return self.chunk_queue.get(timeout=timeout)
         except queue.Empty:
             return None
+
+    def clear_queue(self) -> None:
+        """Remove any queued audio chunks without blocking."""
+
+        try:
+            while True:
+                self.chunk_queue.get_nowait()
+        except queue.Empty:
+            return
 
     def stop(self) -> None:
         """Signal the recorder to stop and wait for the background thread."""
@@ -372,6 +381,7 @@ class SpeechSegment:
     sample_rate: int
     channels: int = 1
     sampwidth: int = 2
+    text: str = ""
 
 
 @dataclass
@@ -610,7 +620,7 @@ class BufferedTTS:
 
 
     def generate_and_queue(self, text: str, segment_id: int) -> Optional[Future]:
-        clean_text = (text or "").strip()
+        clean_text = " ".join((text or "").split())
         if not clean_text:
             return None
         return self.executor.submit(self._generate_speech, clean_text, segment_id)
@@ -620,6 +630,10 @@ class BufferedTTS:
 
         if not self.model_path.exists():
             print(f"[TTS] Piper model not found: {self.model_path}")
+            return None
+
+        utterance = " ".join((text or "").split())
+        if not utterance:
             return None
 
         info = self._voice_info
@@ -633,9 +647,10 @@ class BufferedTTS:
             tmp_path = Path(tmp_file.name)
         keep_file = False
         try:
+            input_bytes = (utterance + "\n").encode("utf-8")
             proc = subprocess.run(
                 cmd,
-                input=text.encode("utf-8"),
+                input=input_bytes,
                 capture_output=True,
                 check=True,
                 timeout=self.timeout,
@@ -652,11 +667,13 @@ class BufferedTTS:
                 wf.writeframes(audio_bytes)
             keep_file = True
 
+            sample_rate = info.sample_rate or 22050
             segment = SpeechSegment(
                 path=str(tmp_path),
                 raw=audio_bytes,
-                sample_rate=info.sample_rate or 22050,
+                sample_rate=sample_rate,
                 channels=info.channels or 1,
+                text=utterance,
             )
             self.speech_queue.put(segment)
             return segment
@@ -776,6 +793,7 @@ class ParallelVoiceAssistant:
         self._activity_event = threading.Event()
         self._last_voice_time = time.time()
         self._has_detected_speech = False
+        self._first_voice_time: Optional[float] = None
         self._recording_stop_time: Optional[float] = None
         self._silence_timeout = float(silence_timeout)
         self._silence_threshold = float(silence_threshold)
@@ -800,11 +818,17 @@ class ParallelVoiceAssistant:
             r"\b(blank[_ ]?audio|wind blowing|bird chirping)\b", flags=re.IGNORECASE
         )
 
+        self._tts_futures_lock = threading.Lock()
+        self._pending_tts_futures: Set[Future] = set()
+
 
     def _register_activity(self) -> None:
+        now = time.time()
         with self._activity_lock:
+            if not self._has_detected_speech:
+                self._first_voice_time = now
             self._has_detected_speech = True
-            self._last_voice_time = time.time()
+            self._last_voice_time = now
         self._activity_event.set()
 
     def _is_silent_chunk(self, audio_chunk: np.ndarray) -> bool:
@@ -829,6 +853,7 @@ class ParallelVoiceAssistant:
             self.stats.recording_stop_time = self._recording_stop_time
         print(reason)
         self.recorder.stop()
+        self.recorder.clear_queue()
         self._activity_event.set()
 
     def _handle_silent_audio_chunk(self) -> None:
@@ -878,7 +903,11 @@ class ParallelVoiceAssistant:
         with self._activity_lock:
             self._has_detected_speech = False
             self._last_voice_time = start_time
+            self._first_voice_time = None
         self._recording_stop_time = None
+
+        with self._tts_futures_lock:
+            self._pending_tts_futures.clear()
 
         with self._stop_lock:
             self._stop_requested = False
@@ -954,6 +983,7 @@ class ParallelVoiceAssistant:
 
         self.stt.shutdown()
         self.llm.shutdown()
+        self._wait_for_tts_completion()
         self.tts.stop()
 
         elapsed = time.time() - start_time
@@ -969,6 +999,11 @@ class ParallelVoiceAssistant:
                 if audio_chunk is None:
                     self._process_stt_results(wait=False)
                     continue
+
+                if self._stop_requested and not self.recorder.recording:
+                    self.recorder.clear_queue()
+                    self._process_stt_results(wait=False)
+                    break
 
                 # remember recorder sample rate for VAD logic if needed
                 setattr(self, "_recorder_sample_rate", self.recorder.sample_rate)
@@ -1102,21 +1137,23 @@ class ParallelVoiceAssistant:
 
             self.stats.llm_latencies.append(latency)
 
-            if (
-                self.stats.recording_to_first_llm_latency is None
-                and self._recording_stop_time is not None
-            ):
-                self.stats.recording_to_first_llm_latency = max(
-                    0.0, response_ready_time - self._recording_stop_time
-                )
+            if self.stats.recording_to_first_llm_latency is None:
+                first_voice_time: Optional[float]
+                with self._activity_lock:
+                    first_voice_time = self._first_voice_time
 
-            elif (
-                self.stats.recording_to_first_llm_latency is None
-                and self._recording_stop_time is None
-            ):
-                self.stats.recording_to_first_llm_latency = max(
-                    0.0, response_ready_time - reference_timestamp
-                )
+                if first_voice_time is not None:
+                    self.stats.recording_to_first_llm_latency = max(
+                        0.0, response_ready_time - first_voice_time
+                    )
+                elif self._recording_stop_time is not None:
+                    self.stats.recording_to_first_llm_latency = max(
+                        0.0, response_ready_time - self._recording_stop_time
+                    )
+                else:
+                    self.stats.recording_to_first_llm_latency = max(
+                        0.0, response_ready_time - reference_timestamp
+                    )
 
 
             response = (response or "").strip()
@@ -1137,6 +1174,8 @@ class ParallelVoiceAssistant:
                 future = self.tts.generate_and_queue(sentence, segment_id)
                 if future is not None:
                     self.stats.tts_segments += 1
+                    with self._tts_futures_lock:
+                        self._pending_tts_futures.add(future)
                     tts_jobs.append((future, submit_time))
                 segment_id += 1
 
@@ -1161,13 +1200,15 @@ class ParallelVoiceAssistant:
         except Exception as exc:
             print(f"[TTS Pipeline] Generation failed: {exc}")
             self._handle_failed_tts_generation(pending)
-            return
-
-        if result:
-            latency = max(0.0, time.time() - start_time)
-            self.stats.tts_generation_latencies.append(latency)
         else:
-            self._handle_failed_tts_generation(pending)
+            if result:
+                latency = max(0.0, time.time() - start_time)
+                self.stats.tts_generation_latencies.append(latency)
+            else:
+                self._handle_failed_tts_generation(pending)
+        finally:
+            with self._tts_futures_lock:
+                self._pending_tts_futures.discard(future)
 
     def _handle_failed_tts_generation(self, pending: PendingOutput) -> None:
         with self._pending_lock:
@@ -1280,6 +1321,31 @@ class ParallelVoiceAssistant:
         self._print_latency_summary("Input -> first audio gap", list(self.stats.input_to_output_latencies))
 
         print("----------------------\n")
+
+    def _wait_for_tts_completion(self, timeout: float = 15.0) -> None:
+        if self.stats.tts_segments == 0:
+            return
+
+        deadline = time.time() + max(0.0, timeout)
+        while True:
+            with self._tts_futures_lock:
+                pending_futures = len(self._pending_tts_futures)
+
+            with self._pending_lock:
+                pending_outputs = sum(
+                    1 for pending in self.stats.pending_outputs if pending.segments_expected > 0
+                )
+
+            queue_empty = self.tts.speech_queue.empty()
+
+            if pending_futures == 0 and pending_outputs == 0 and queue_empty:
+                break
+
+            if time.time() >= deadline:
+                print("[TTS] Timeout waiting for pending audio playback; continuing shutdown.")
+                break
+
+            time.sleep(0.05)
 
 
 # ================================================================


### PR DESCRIPTION
## Summary
- track the first detected speech timestamp and use it when reporting the latency to the initial LLM reply
- record pending Piper synthesis tasks and pause shutdown until they finish so queued speech is played back
- reset tracked TTS futures between runs to keep repeated sessions consistent

## Testing
- python -m compileall pipeline.py

