### PR TITLE
Add adaptive noise floor handling for silence

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -847,6 +847,7 @@ class ParallelVoiceAssistant:
         self._pending_tts_futures: Set[Future] = set()
 
         self._chunk_activity: Dict[int, bool] = {}
+        self._chunk_energy: Dict[int, Tuple[float, float]] = {}
         self._awaiting_transcript_chunks = 0
         self._awaiting_transcript_started_at: Optional[float] = None
         self._awaiting_transcript_chunk_limit = max(2, int(math.ceil(4.0 / max(0.1, self._chunk_duration))))
@@ -854,6 +855,10 @@ class ParallelVoiceAssistant:
         self._stt_flush_in_progress = False
         self._next_finalize_id = 1_000_000
         self._active_flush_ids: Set[int] = set()
+
+        self._noise_floor_rms: Optional[float] = None
+        self._noise_floor_peak: Optional[float] = None
+        self._noise_floor_updates = 0
 
 
 
@@ -897,8 +902,45 @@ class ParallelVoiceAssistant:
         self._reset_awaiting_transcript_state()
         self._next_finalize_id += 1
 
-    def _is_silent_chunk(self, audio_chunk: np.ndarray) -> bool:
+    def _reset_noise_floor(self) -> None:
+        self._noise_floor_rms = None
+        self._noise_floor_peak = None
+        self._noise_floor_updates = 0
+
+    def _update_noise_floor(self, rms: float, peak: float) -> None:
+        rms = max(0.0, float(rms))
+        peak = max(0.0, float(peak))
+
+        if self._noise_floor_rms is None:
+            self._noise_floor_rms = rms
+            self._noise_floor_peak = peak
+        else:
+            alpha = 0.2
+            assert self._noise_floor_peak is not None
+            self._noise_floor_rms = (1.0 - alpha) * self._noise_floor_rms + alpha * rms
+            self._noise_floor_peak = (1.0 - alpha) * self._noise_floor_peak + alpha * peak
+
+        self._noise_floor_updates = min(self._noise_floor_updates + 1, 1_000_000)
+
+    def _noise_thresholds(self) -> Tuple[float, float]:
+        base_rms = self._noise_floor_rms or 0.0
+        base_peak = self._noise_floor_peak if self._noise_floor_peak is not None else base_rms
+
+        safety_rms_margin = max(75.0, self._silence_threshold * 0.5)
+        safety_peak_margin = max(150.0, self._silence_threshold * 0.75)
+
+        rms_threshold = max(self._silence_threshold, base_rms + safety_rms_margin)
+        peak_threshold = max(self._silence_threshold * 1.5, base_peak + safety_peak_margin)
+
+        return rms_threshold, peak_threshold
+
+    def _energy_matches_noise_floor(self, rms: float, peak: float) -> bool:
+        rms_threshold, peak_threshold = self._noise_thresholds()
+        return rms <= rms_threshold and peak <= peak_threshold
+
+    def _is_silent_chunk(self, chunk_id: int, audio_chunk: np.ndarray) -> bool:
         if audio_chunk.size == 0:
+            self._chunk_energy[chunk_id] = (0.0, 0.0)
             return True
 
         audio_view = np.asarray(audio_chunk, dtype=np.int16)
@@ -907,22 +949,28 @@ class ParallelVoiceAssistant:
 
         audio_float = audio_view.astype(np.float32)
         if audio_float.size == 0:
+            self._chunk_energy[chunk_id] = (0.0, 0.0)
             return True
 
         abs_audio = np.abs(audio_float)
         rms = float(np.sqrt(np.mean(np.square(audio_float))))
-        peak = float(abs_audio.max())
+        peak = float(abs_audio.max()) if abs_audio.size else 0.0
 
-        if rms < self._silence_threshold and peak < (self._silence_threshold * 1.5):
+        self._chunk_energy[chunk_id] = (rms, peak)
+
+        rms_threshold, peak_threshold = self._noise_thresholds()
+
+        if rms <= rms_threshold and peak <= peak_threshold:
             return True
 
         # Guard against sporadic spikes being treated as speech by checking how
         # much of the chunk actually carries energy above the threshold.
-        samples_above = float(np.count_nonzero(abs_audio > self._silence_threshold))
+        energy_threshold = rms_threshold
+        samples_above = float(np.count_nonzero(abs_audio > energy_threshold))
         fraction_above = samples_above / float(abs_audio.size)
-        percentile_95 = float(np.percentile(abs_audio, 95))
+        percentile_95 = float(np.percentile(abs_audio, 95)) if abs_audio.size else 0.0
 
-        if fraction_above < 0.01 and percentile_95 < (self._silence_threshold * 1.4):
+        if fraction_above < 0.01 and percentile_95 <= peak_threshold:
             return True
 
         return False
@@ -1111,20 +1159,17 @@ class ParallelVoiceAssistant:
                 # _handle_silent_audio_chunk() here. We wait for the STT result so we
                 # only count a chunk as "silent" once the model actually returns nothing
                 # useful for that chunk (avoids double-counting).
-                is_silent = self._is_silent_chunk(audio_chunk)
+                is_silent = self._is_silent_chunk(chunk_id, audio_chunk)
                 self._chunk_activity[chunk_id] = not is_silent
                 if is_silent:
                     # don't mark stop here; just log and continue to submit to STT so
                     # the model can confirm whether it's empty/noise
                     # (This prevents short/quiet speech from being mis-classified.)
                     # Optional: print RMS for debugging:
-                    try:
-                        audio_view = np.asarray(audio_chunk, dtype=np.int16)
-                        if audio_view.ndim > 1:
-                            audio_view = audio_view.reshape(-1)
-                        rms = float(np.sqrt(np.mean(np.square(audio_view.astype(np.float32)))))
-                    except Exception:
-                        rms = 0.0
+                    rms = 0.0
+                    energy = self._chunk_energy.get(chunk_id)
+                    if energy is not None:
+                        rms = energy[0]
                     print(f"[STT] Chunk {chunk_id}: low energy (RMS {rms:.1f}), submitting to STT for verification")
                 else:
                     # Defer activity tracking until Whisper confirms actual text for
@@ -1184,7 +1229,8 @@ class ParallelVoiceAssistant:
 
             # Normalize for noise checks
             normalized = (text or "").strip().lower()
-            had_activity = self._chunk_activity.pop(res_chunk_id, False)
+            had_activity = self._chunk_activity.get(res_chunk_id, False)
+            energy = self._chunk_energy.pop(res_chunk_id, None)
 
             # Check blacklist exact matches first, then regex for variants
             is_noise = False
@@ -1195,35 +1241,47 @@ class ParallelVoiceAssistant:
                     is_noise = True
 
             if is_noise or not normalized:
-                if had_activity and not normalized:
-                    # Speech energy was observed for this chunk, but Whisper did not
+                treat_as_noise = True
+                if not normalized and had_activity:
+                    treat_as_noise = False
+                    if energy is None or self._energy_matches_noise_floor(*energy):
+                        treat_as_noise = True
 
-                    # return any transcript yet. Treat as ongoing speech for a short
-                    # period, but force an intermediate transcription if it persists.
-
+                if treat_as_noise:
+                    noise_suffix = ""
+                    if energy is not None:
+                        noise_suffix = f" (RMS {energy[0]:.1f})"
+                        self._update_noise_floor(*energy)
+                    self._chunk_activity[res_chunk_id] = False
                     print(
-                        f"[STT] Chunk {res_chunk_id}: (speech detected, awaiting transcription)"
+                        f"[STT] Chunk {res_chunk_id}: {text} (treated as noise/empty){noise_suffix}"
                     )
-
-                    self._awaiting_transcript_chunks += 1
-                    if self._awaiting_transcript_started_at is None:
-                        self._awaiting_transcript_started_at = time.time()
-                    if self._should_force_intermediate_transcription():
-                        elapsed = 0.0
-                        if self._awaiting_transcript_started_at is not None:
-                            elapsed = time.time() - self._awaiting_transcript_started_at
-                        self._queue_intermediate_transcription(
-                            f"[STT] Forcing intermediate transcription after {elapsed:.1f}s without text"
-                        )
-
+                    self._reset_awaiting_transcript_state()
+                    self._handle_silent_audio_chunk()
+                    self._chunk_activity.pop(res_chunk_id, None)
                     continue
 
-                # Treat as silent/noise: increment silent-chunk logic and DO NOT feed to LLM
-                print(f"[STT] Chunk {res_chunk_id}: {text} (treated as noise/empty)")
-                self._reset_awaiting_transcript_state()
-                self._handle_silent_audio_chunk()
-                # We still want to surface the log, but skip registering activity and LLM trigger
-                # continue to next future
+                # Speech energy was observed for this chunk, but Whisper did not
+                # return any transcript yet. Treat as ongoing speech for a short
+                # period, but force an intermediate transcription if it persists.
+                print(
+                    f"[STT] Chunk {res_chunk_id}: (speech detected, awaiting transcription)"
+                )
+
+                self._awaiting_transcript_chunks += 1
+                if self._awaiting_transcript_started_at is None:
+                    self._awaiting_transcript_started_at = time.time()
+                if self._should_force_intermediate_transcription():
+                    elapsed = 0.0
+                    if self._awaiting_transcript_started_at is not None:
+                        elapsed = time.time() - self._awaiting_transcript_started_at
+                    self._queue_intermediate_transcription(
+                        f"[STT] Forcing intermediate transcription after {elapsed:.1f}s without text"
+                    )
+                    self._reset_noise_floor()
+                    self._consecutive_silent_chunks = 0
+
+                self._chunk_activity.pop(res_chunk_id, None)
                 continue
 
             # Otherwise it's valid speech
@@ -1232,6 +1290,8 @@ class ParallelVoiceAssistant:
             self._consecutive_silent_chunks = 0
 
             print(f"[STT] Chunk {res_chunk_id}: {text}")
+
+            self._chunk_activity.pop(res_chunk_id, None)
 
 
 


### PR DESCRIPTION
## Summary
- track per-chunk energy levels and maintain an adaptive noise floor that is updated when Whisper confirms a chunk is empty
- use the adaptive thresholds inside `_is_silent_chunk` and silence logging so idle chunks are identified against the rolling baseline
- adjust STT result handling to mark noise chunks as inactive, update the noise floor, and reset silence tracking after forced flushes

## Testing
- python pipeline.py *(fails: PortAudio library not found)*

