### PR TITLE
Improve silence handling responsiveness

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -287,9 +287,21 @@ class ParallelSTT:
 
     # -------------------------- Public API -----------------------
 
-    def submit_chunk(self, audio_chunk: np.ndarray, chunk_id: int) -> Future:
+    def submit_chunk(
+        self,
+        audio_chunk: np.ndarray,
+        chunk_id: int,
+        *,
+        skip_transcription: bool = False,
+    ) -> Future:
 
         audio_bytes = np.ascontiguousarray(audio_chunk, dtype=np.int16).tobytes()
+
+        if skip_transcription:
+            future: "Future[Dict[str, Any]]" = Future()
+            future.set_result({"chunk_id": chunk_id, "text": "", "is_final": False})
+            return future
+
         with self._transcript_lock:
             self._chunks.append(audio_bytes)
 
@@ -1098,6 +1110,8 @@ class ParallelVoiceAssistant:
         self._pending_tts_futures: Set[Future] = set()
 
         self._chunk_activity: Dict[int, bool] = {}
+        self._pending_silence_chunk_ids: Deque[int] = deque()
+        self._counted_silence_chunk_ids: Set[int] = set()
         self._awaiting_transcript_chunks = 0
         self._awaiting_transcript_started_at: Optional[float] = None
         self._awaiting_transcript_chunk_limit = max(2, int(math.ceil(4.0 / max(0.1, self._chunk_duration))))
@@ -1153,6 +1167,9 @@ class ParallelVoiceAssistant:
         self._awaiting_transcript_chunks = 0
         self._awaiting_transcript_started_at = None
 
+    def _reset_pending_silence_tracking(self) -> None:
+        self._pending_silence_chunk_ids.clear()
+
     def _should_force_intermediate_transcription(self) -> bool:
         if self._stt_flush_in_progress:
             return False
@@ -1206,9 +1223,9 @@ class ParallelVoiceAssistant:
         self._activity_event.set()
 
     def _handle_silent_audio_chunk(self) -> None:
+        self._consecutive_silent_chunks += 1
         if self._stop_requested:
             return
-        self._consecutive_silent_chunks += 1
         if self._consecutive_silent_chunks < self._silent_chunks_before_stop:
             return
         if self._has_detected_speech:
@@ -1265,6 +1282,8 @@ class ParallelVoiceAssistant:
             self._stop_requested = False
             self._stop_reason = None
         self._consecutive_silent_chunks = 0
+        self._reset_pending_silence_tracking()
+        self._counted_silence_chunk_ids.clear()
         self._reset_awaiting_transcript_state()
         self._stt_flush_in_progress = False
         self._active_flush_ids.clear()
@@ -1363,17 +1382,11 @@ class ParallelVoiceAssistant:
                 # remember recorder sample rate for VAD logic if needed
                 setattr(self, "_recorder_sample_rate", self.recorder.sample_rate)
 
-                # Decide whether this chunk is silent/noisy for logging, but DO NOT call
-                # _handle_silent_audio_chunk() here. We wait for the STT result so we
-                # only count a chunk as "silent" once the model actually returns nothing
-                # useful for that chunk (avoids double-counting).
                 is_silent = self._is_silent_chunk(audio_chunk)
                 self._chunk_activity[chunk_id] = not is_silent
+                skip_transcription = False
                 if is_silent:
-                    # don't mark stop here; just log and continue to submit to STT so
-                    # the model can confirm whether it's empty/noise
-                    # (This prevents short/quiet speech from being mis-classified.)
-                    # Optional: print RMS for debugging:
+                    self._pending_silence_chunk_ids.append(chunk_id)
                     try:
                         audio_view = np.asarray(audio_chunk, dtype=np.int16)
                         if audio_view.ndim > 1:
@@ -1381,15 +1394,28 @@ class ParallelVoiceAssistant:
                         rms = float(np.sqrt(np.mean(np.square(audio_view.astype(np.float32)))))
                     except Exception:
                         rms = 0.0
-                    print(f"[STT] Chunk {chunk_id}: low energy (RMS {rms:.1f}), submitting to STT for verification")
+                    print(
+                        f"[STT] Chunk {chunk_id}: low energy (RMS {rms:.1f}), submitting to STT for verification"
+                    )
+
+                    if len(self._pending_silence_chunk_ids) >= self._silent_chunks_before_stop:
+                        for pending_chunk_id in list(self._pending_silence_chunk_ids):
+                            if pending_chunk_id in self._counted_silence_chunk_ids:
+                                continue
+                            self._counted_silence_chunk_ids.add(pending_chunk_id)
+                            self._handle_silent_audio_chunk()
+                            if self._stop_requested:
+                                break
+                    skip_transcription = True
                 else:
-                    # Mark provisional activity so the main loop can begin silence
-                    # tracking even before Whisper confirms the transcript.
+                    self._reset_pending_silence_tracking()
                     self._mark_provisional_activity(chunk_id)
 
-                # Submit to STT as usual (we rely on _process_stt_results to treat
-                # empty/noise transcriptions as silent and call _handle_silent_audio_chunk()).
-                future = self.stt.submit_chunk(audio_chunk, chunk_id)
+                future = self.stt.submit_chunk(
+                    audio_chunk,
+                    chunk_id,
+                    skip_transcription=skip_transcription,
+                )
                 self.stt_futures.put((chunk_id, future, time.time()))
 
                 self.stats.stt_chunks += 1
@@ -1481,6 +1507,8 @@ class ParallelVoiceAssistant:
                         # this as silence so we still stop after the configured no-speech chunks.
                         self._reset_awaiting_transcript_state()
                         self._clear_provisional_activity(res_chunk_id)
+                        if res_chunk_id not in self._counted_silence_chunk_ids:
+                            self._counted_silence_chunk_ids.add(res_chunk_id)
                         self._handle_silent_audio_chunk()
                         continue
                     if self._should_force_intermediate_transcription():
@@ -1497,13 +1525,17 @@ class ParallelVoiceAssistant:
                 print(f"[STT] Chunk {res_chunk_id}: {text} (treated as noise/empty)")
                 self._reset_awaiting_transcript_state()
                 self._clear_provisional_activity(res_chunk_id)
-                self._handle_silent_audio_chunk()
+                if res_chunk_id not in self._counted_silence_chunk_ids:
+                    self._handle_silent_audio_chunk()
+                    self._counted_silence_chunk_ids.add(res_chunk_id)
                 # We still want to surface the log, but skip registering activity and LLM trigger
                 # continue to next future
                 continue
 
             # Otherwise it's valid speech
             self._reset_awaiting_transcript_state()
+            self._counted_silence_chunk_ids.discard(res_chunk_id)
+            self._reset_pending_silence_tracking()
             self._register_activity(chunk_id=res_chunk_id)
             self._consecutive_silent_chunks = 0
 

--- a/tests/test_pipeline_silence.py
+++ b/tests/test_pipeline_silence.py
@@ -4,7 +4,7 @@ import threading
 import time
 import unittest
 from pathlib import Path
-from typing import Dict, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
 
 import numpy as np
 
@@ -48,15 +48,33 @@ class FakeRecorder:
 
 
 class FakeSTT:
-    def __init__(self, responses: Dict[int, Tuple[float, Dict[str, object]]]) -> None:
+    def __init__(
+        self,
+        responses: Dict[int, Tuple[float, Dict[str, object]]],
+        emit_partials: bool = False,
+    ) -> None:
         self._responses = responses
+        self.emit_partials = emit_partials
 
-    def submit_chunk(self, _audio_chunk: np.ndarray, chunk_id: int):
-        delay, result = self._responses.get(chunk_id, (0.0, {}))
-        future: "Future[Dict[str, object]]"
+    def submit_chunk(
+        self,
+        _audio_chunk: np.ndarray,
+        chunk_id: int,
+        *,
+        skip_transcription: bool = False,
+    ):
         from concurrent.futures import Future
 
-        future = Future()
+        future: "Future[Dict[str, object]]" = Future()
+        if skip_transcription:
+            future.set_result({"chunk_id": chunk_id, "text": "", "is_final": False})
+            return future
+
+        delay, result = self._responses.get(chunk_id, (0.0, {}))
+        if delay <= 0:
+            future.set_result(result)
+            return future
+
         future.set_running_or_notify_cancel()
 
         def _resolve() -> None:
@@ -84,6 +102,8 @@ class FakeLLM:
 class FakeTTS:
     def __init__(self) -> None:
         self.speech_queue: "queue.Queue[object]" = queue.Queue()
+        self.on_playback_start: Optional[Callable[[str, float], None]] = None
+        self.on_playback_error: Optional[Callable[[], None]] = None
 
     def start_playback(self) -> None:
         pass
@@ -93,6 +113,54 @@ class FakeTTS:
 
     def shutdown(self) -> None:
         pass
+
+
+class RespondingLLM:
+    def __init__(self, response: str, delay: float = 0.05) -> None:
+        self.response = response
+        self.delay = delay
+
+    def process_incremental(self, text: str, is_final: bool = False):
+        if not text.strip():
+            return None
+
+        from concurrent.futures import Future
+
+        future: "Future[str]" = Future()
+
+        def _resolve() -> None:
+            time.sleep(self.delay)
+            future.set_result(self.response)
+
+        threading.Thread(target=_resolve, daemon=True).start()
+        return future
+
+    def shutdown(self) -> None:
+        pass
+
+
+class PendingTTS(FakeTTS):
+    def __init__(self, delay: float = 0.3) -> None:
+        super().__init__()
+        self.delay = delay
+        self.completed_times: List[float] = []
+
+    def generate_and_queue(self, text: str, segment_id: int):
+        from concurrent.futures import Future
+
+        future: "Future[object]" = Future()
+
+        def _resolve() -> None:
+            time.sleep(self.delay)
+            completion_time = time.time()
+            self.completed_times.append(completion_time)
+            future.set_result({"text": text, "segment_id": segment_id})
+            callback = getattr(self, "on_playback_start", None)
+            if callable(callback):
+                callback(f"segment_{segment_id}.wav", completion_time)
+
+        threading.Thread(target=_resolve, daemon=True).start()
+        return future
 
 
 class SilenceTimeoutTestCase(unittest.TestCase):
@@ -110,13 +178,14 @@ class SilenceTimeoutTestCase(unittest.TestCase):
         self._tmp.cleanup()
 
     def _create_assistant(self, **kwargs) -> ParallelVoiceAssistant:
+        emit_partials = kwargs.get("emit_partials", False)
         assistant = ParallelVoiceAssistant(
             chunk_duration=kwargs.get("chunk_duration", 0.05),
             sample_rate=16000,
             stt_workers=1,
             whisper_exe=self.whisper_exe,
             whisper_model=self.whisper_model,
-            emit_stt_partials=False,
+            emit_stt_partials=emit_partials,
             piper_model_path=self.tmp_path / "voice.onnx",
             use_subprocess_playback=False,
             silence_timeout=kwargs.get("silence_timeout", 0.35),
@@ -125,8 +194,11 @@ class SilenceTimeoutTestCase(unittest.TestCase):
 
         assistant.recorder = kwargs["recorder"]
         assistant.stt = kwargs["stt"]
-        assistant.llm = FakeLLM()
-        assistant.tts = FakeTTS()
+        setattr(assistant.stt, "emit_partials", emit_partials)
+        assistant.llm = kwargs.get("llm", FakeLLM())
+        assistant.tts = kwargs.get("tts", FakeTTS())
+        setattr(assistant.tts, "on_playback_start", assistant._on_tts_playback_start)
+        setattr(assistant.tts, "on_playback_error", assistant._on_tts_playback_error)
         return assistant
 
     def test_emit_partials_false_stops_after_silence(self) -> None:
@@ -183,6 +255,55 @@ class SilenceTimeoutTestCase(unittest.TestCase):
         self.assertEqual(assistant._pending_activity, {})
         self.assertFalse(assistant._has_detected_speech)
         self.assertIsNone(assistant._first_voice_time)
+
+    def _run_silence_with_pending_tts(self, emit_partials: bool) -> None:
+        speech = (np.ones(int(0.05 * 16000), dtype=np.int16) * 2500).astype(np.int16)
+        silence = np.zeros_like(speech)
+        recorder = FakeRecorder((speech, silence, silence))
+
+        stt = FakeSTT(
+            {
+                0: (
+                    0.0,
+                    {"chunk_id": 0, "text": "hello there", "is_final": True},
+                )
+            },
+            emit_partials=emit_partials,
+        )
+        llm = RespondingLLM("Sure thing.", delay=0.05)
+        tts = PendingTTS(delay=0.4)
+
+        assistant = self._create_assistant(
+            recorder=recorder,
+            stt=stt,
+            llm=llm,
+            tts=tts,
+            emit_partials=emit_partials,
+            silence_threshold=150.0,
+        )
+
+        start = time.time()
+        assistant.run(duration=3.0)
+        elapsed = time.time() - start
+
+        self.assertGreater(assistant.stats.tts_segments, 0)
+        self.assertIsNotNone(assistant._recording_stop_time)
+        assert assistant._recording_stop_time is not None
+        stop_offset = assistant._recording_stop_time - assistant.stats.start_time
+        self.assertLess(stop_offset, 0.8, msg=f"stop offset too large: {stop_offset:.3f}s")
+        self.assertIsNotNone(assistant._stop_reason)
+        assert assistant._stop_reason is not None
+        self.assertIn("consecutive chunks", assistant._stop_reason)
+        self.assertTrue(tts.completed_times)
+        first_completion = min(tts.completed_times)
+        self.assertLess(assistant._recording_stop_time, first_completion)
+        self.assertLess(elapsed, 3.0)
+
+    def test_silence_stops_recorder_with_pending_tts_no_partials(self) -> None:
+        self._run_silence_with_pending_tts(emit_partials=False)
+
+    def test_silence_stops_recorder_with_pending_tts_with_partials(self) -> None:
+        self._run_silence_with_pending_tts(emit_partials=True)
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary
- track consecutive silent chunks in the STT pipeline and increment the stop counter immediately when the silence threshold is met
- allow `ParallelSTT.submit_chunk` to skip whisper transcription for obviously silent chunks and make `_handle_silent_audio_chunk` increment before checking for stop requests
- add regression tests that simulate pending TTS responses while silence is detected with and without STT partials enabled

